### PR TITLE
remove whitespace between @ and address

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Converts elf files into mem files, following the `$readmemh()` format, with address in hex, data in hex values and optional comments as the example below.
 
 ```text
-@ DEADBEEF // deadbeat address followed by data
+@DEADBEEF // deadbeat address followed by data
 000FF1CE // office
 DEAD10CC // deadlock
 BAAAAAAD // baaad
 
-@ 0xC00010FF // cooloff address followed by data
+@C00010FF // cooloff address followed by data
 0D15EA5E  // zero disease  
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn dump_section(
     );
 
     writeln!(f_out, "// section {:?}", sh.get_name(elf)?)?;
-    writeln!(f_out, "@ {:x?}", sh.address())?;
+    writeln!(f_out, "@{:x?}", sh.address())?;
     let slice = &data[sh.offset() as usize..(sh.offset() + sh.size()) as usize];
     for (i, d) in slice.iter().enumerate() {
         write!(f_out, "{:02x?}{}", d, if packed { "" } else { " " })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,13 @@ use clap::Parser;
 )]
 
 struct Cli {
-    /// Optional name for generated mem file [default: <input file>.mem)
-    #[arg(short, long)]
-    out: Option<PathBuf>,
+    /// Optional name for generated .data file [default: <input file>_data.mem)
+    #[arg(short = 'd', long)]
+    out_data: Option<PathBuf>,
+
+    // Optional name for generated .text file [default: <input file>_text.mem]
+    #[arg(short = 't', long)]
+    out_text: Option<PathBuf>,
 
     /// Input file in elf format
     #[arg(short, long, default_value = "app.elf")]
@@ -30,15 +34,29 @@ struct Cli {
     /// Packed (no spaces between bytes)
     #[arg(short, long)]
     packed: bool,
+
+    /// Flip the byte order of the loaded words
+    #[arg(short, long, default_value = "true")]
+    flip_endianness: bool,
 }
 fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
 
-    let out_path: PathBuf = if let Some(out) = cli.out.as_deref() {
+    let out_path_data: PathBuf = if let Some(out) = cli.out_data.as_deref() {
         println!("Value for name: {:?}", out);
         out.to_owned()
     } else {
         let mut p: PathBuf = cli.file.clone();
+        p.set_file_name(format!("{}_data", p.file_name().unwrap().to_str().unwrap()));
+        p.set_extension("mem");
+        p
+    };
+    let out_path_text: PathBuf = if let Some(out) = cli.out_text.as_deref() {
+        println!("Value for name: {:?}", out);
+        out.to_owned()
+    } else {
+        let mut p: PathBuf = cli.file.clone();
+        p.set_file_name(format!("{}_text", p.file_name().unwrap().to_str().unwrap()));
         p.set_extension("mem");
         p
     };
@@ -46,16 +64,33 @@ fn main() -> Result<(), Box<dyn Error>> {
     let in_path = cli.file;
 
     let file_data = fs::read(in_path.clone())?;
-    let mut f_out = fs::File::create(out_path.clone())?;
+    let mut f_out_text = fs::File::create(out_path_text.clone())?;
+    let mut f_out_data = fs::File::create(out_path_data.clone())?;
 
     let data = file_data.as_slice();
     let elf = ElfFile::new(data)?;
 
-    println!("elf2mem -f {:?} -o {:?}\n", in_path, out_path);
+    //println!("elf2mem -f {:?} -o {:?}\n", in_path, out_path);
     let text_section = elf.find_section_by_name(".text").unwrap();
-    dump_section(&elf, text_section, data, cli.width, cli.packed, &mut f_out)?;
+    dump_section(
+        &elf,
+        text_section,
+        data,
+        cli.width,
+        cli.packed,
+        &mut f_out_text,
+        cli.flip_endianness,
+    )?;
     let data_section = elf.find_section_by_name(".data").unwrap();
-    dump_section(&elf, data_section, data, cli.width, cli.packed, &mut f_out)?;
+    dump_section(
+        &elf,
+        data_section,
+        data,
+        cli.width,
+        cli.packed,
+        &mut f_out_data,
+        cli.flip_endianness,
+    )?;
 
     Ok(())
 }
@@ -67,6 +102,7 @@ fn dump_section(
     width: u8,
     packed: bool,
     f_out: &mut File,
+    flip: bool,
 ) -> Result<(), Box<dyn Error>> {
     println!(
         "section {:?}, address {:#10x}, size {:#10x}",
@@ -76,9 +112,24 @@ fn dump_section(
     );
 
     writeln!(f_out, "// section {:?}", sh.get_name(elf)?)?;
-    writeln!(f_out, "@{:x?}", sh.address())?;
-    let slice = &data[sh.offset() as usize..(sh.offset() + sh.size()) as usize];
-    for (i, d) in slice.iter().enumerate() {
+    writeln!(f_out, "@{:x?}", sh.address() / width as u64)?;
+    let mut v = vec![];
+    let slice = if flip {
+        let d = &data[sh.offset() as usize..(sh.offset() + sh.size()) as usize];
+        for chunk in d.chunks(4).into_iter() {
+            let mut c = chunk.to_owned();
+            c.reverse();
+            for b in c {
+                v.push(b);
+            }
+        }
+        v.as_slice()
+    } else {
+        let d = &data[sh.offset() as usize..(sh.offset() + sh.size()) as usize];
+        d
+    };
+
+    for (i, d) in slice.into_iter().enumerate() {
         write!(f_out, "{:02x?}{}", d, if packed { "" } else { " " })?;
         if (i + 1) % width as usize == 0 {
             writeln!(f_out)?;


### PR DESCRIPTION
whitespace between address and @ sign (``@ DEADBEEF`` instead of ``@DEADBEEF``) breaks with spec.